### PR TITLE
Add checking for main module's separate .pod file

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Dist-Zilla-Plugin-Pod2Readme
 
 {{$NEXT}}
 
+    - Add checking for main module's separate .pod file
+
 0.004     2017-04-02 13:32:28-04:00 America/New_York
 
     - No changes from 0.003-TRIAL

--- a/corpus/DZT2/lib/DZT/Sample.pm
+++ b/corpus/DZT2/lib/DZT/Sample.pm
@@ -1,0 +1,12 @@
+use strict;
+use warnings;
+
+package DZT::Sample;
+
+sub return_arrayref_of_values_passed {
+    my $invocant = shift;
+    return \@_;
+}
+
+1;
+

--- a/corpus/DZT2/lib/DZT/Sample.pod
+++ b/corpus/DZT2/lib/DZT/Sample.pod
@@ -1,0 +1,9 @@
+=head1 NAME
+
+DZT::Sample - a sample of stuff
+
+=head1 DESCRIPTION
+
+Foo the foo
+
+=cut

--- a/lib/Dist/Zilla/Plugin/Pod2Readme.pm
+++ b/lib/Dist/Zilla/Plugin/Pod2Readme.pm
@@ -53,6 +53,9 @@ sub gather_files {
                     my $parser = Pod::Text->new();
                     $parser->output_string( \( my $text ) );
                     my $filename = $self->source_filename;
+                    my $pod_filename = $filename;
+                    $pod_filename =~ s/\.pm$/.pod/;
+                    $filename = $pod_filename if -f $pod_filename;
                     my $source = List::Util::first { $_->name eq $filename } @{ $self->zilla->files };
                     $self->log_fatal("File $filename not found to extract readme")
                       unless defined $source;

--- a/t/pod2readme.t
+++ b/t/pod2readme.t
@@ -7,6 +7,8 @@ use Test::DZil;
 
 my $root = 'corpus/DZ';
 
+# Test with pod source in the main module's .pm file
+
 {
     my $tzil = Builder->from_config( { dist_root => 'corpus/DZT' },
         { add_files => { 'source/dist.ini' => simple_ini(qw/GatherDir Pod2Readme/) } } );
@@ -21,6 +23,26 @@ my $root = 'corpus/DZ';
 
     like( $contents, qr{Foo the foo}, "description appears in README" );
 }
+
+# Test with pod source in the main module's corresponding .pod file
+
+{
+    my $tzil = Builder->from_config( { dist_root => 'corpus/DZT2' },
+        { add_files => { 'source/dist.ini' => simple_ini(qw/GatherDir Pod2Readme/) } } );
+
+    ok( $tzil, "created test dist" );
+
+    $tzil->build;
+
+    my $contents = $tzil->slurp_file('build/README');
+
+    like( $contents, qr{DZT::Sample}, "dist name appears in README", );
+
+    like( $contents, qr{Foo the foo}, "description appears in README" );
+}
+
+# Test with pod source in an explicitly named file (source_filename
+# parameter)
 
 {
     my $tzil = Builder->from_config(


### PR DESCRIPTION
Hi, I'm using Pod2Readme via the Starter bundle, and was surprised to discover that it was producing an empty README file. My main module's pod source is in a separate .pod file alongside the .pm file. I used the source_filename parameter to specify the .pod file and it worked, but I didn't think I should need to do that (since I don't need to specify the main module anywhere else in dist.ini). My understanding is that a separate .pod file is a reasonably normal thing to do.

So this patch makes Pod2Readme check for the existence of a separate .pod file for the main module, and uses that as the source instead without requiring the user to resort to an explicit source_filename parameter.